### PR TITLE
fix: issue #7 - add require to capybara on hails_helper file

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -19,7 +19,7 @@ Rails.application.configure do
   config.public_file_server.headers = { "cache-control" => "public, max-age=3600" }
 
   # Show full error reports.
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false
   config.cache_store = :null_store
 
   # Render exception templates for rescuable exceptions and raise for other exceptions.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -8,6 +8,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 # that will avoid rails generators crashing because migrations haven't been run yet
 # return unless Rails.env.test?
 require 'rspec/rails'
+require 'capybara/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -33,13 +34,11 @@ rescue ActiveRecord::PendingMigrationError => e
   abort e.to_s.strip
 end
 RSpec.configure do |config|
-  # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures
-  config.fixture_paths = [
-    Rails.root.join('spec/fixtures')
-  ]
-  
-  config.before(type: :system) do
-    driven_by(:rack_test)
+  Capybara.server = :puma, { Silent: true   }
+  Capybara.raise_server_errors = false
+
+  config.before(:each, type: :system) do
+    driven_by :rack_test
   end
   # If you're not using ActiveRecord, or you'd prefer not to run each of your
   # examples within a transaction, remove the following line or assign false
@@ -64,7 +63,7 @@ RSpec.configure do |config|
   # behaviour is considered legacy and will be removed in a future version.
   #
   # To enable this behaviour uncomment the line below.
-  # config.infer_spec_type_from_file_location!
+  config.infer_spec_type_from_file_location!
 
   # Filter lines from Rails gems in backtraces.
   config.filter_rails_from_backtrace!

--- a/spec/system/user_see_homepage_spec.rb
+++ b/spec/system/user_see_homepage_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+describe 'User sees homepage' do
+  it 'sees homepage' do
+    visit root_path
+    expect(page).to have_content('Bem vindo')
+  end
+end


### PR DESCRIPTION
Esse PR resolver um problema na importação das variaveis do capybara que não estavam configuradas no projeto.

foi adicionado a seguinte linha de código no arquivo rails_helper.

`require 'capybara/rspec'`

![image](https://github.com/user-attachments/assets/4096a68e-6771-4bb5-8675-954b4f51ed5d)


E após essa pequena mudança eu conseguir efetuar o teste de forma correta.